### PR TITLE
[configure.ac/install-symlink] Fixing rocc-template by addressing several issues

### DIFF
--- a/install-symlinks
+++ b/install-symlinks
@@ -1,8 +1,23 @@
 #!/usr/bin/env bash
 #see LICENSE for license
 
-cd ../ && ln -s rocc-template sha3
-mv Makefrag Makefrag.old && ln -s sha3/config/Makefrag Makefrag
-cd riscv-tools/riscv-isa-sim && ln -s ../../sha3/isa-sim/sha3 sha3
-mv configure.ac configure.ac.old && ln -s ../../sha3/isa-sim/configure.ac && ln -s ../../sha3/isa-sim/riscv-sha3.pc.in riscv-sha3.pc.in
-cd ../../src/main/scala && ln -s ../../../sha3/config/PrivateConfigs.scala PrivateConfigs.scala
+# hawajkm: Fixing this script to be repeatable. Currently, ran twice, this would break and cause an exist code greater than zero; thus, effectively cause the Makefile target to fail.
+
+#cd ../ && ln -s rocc-template sha3
+#mv Makefrag Makefrag.old && ln -s sha3/config/Makefrag Makefrag
+#cd riscv-tools/riscv-isa-sim && ln -s ../../sha3/isa-sim/sha3 sha3
+#mv configure.ac configure.ac.old && ln -s ../../sha3/isa-sim/configure.ac && ln -s ../../sha3/isa-sim/riscv-sha3.pc.in riscv-sha3.pc.in
+#cd ../../src/main/scala && ln -s ../../../sha3/config/PrivateConfigs.scala PrivateConfigs.scala
+
+
+# hawajkm: The following work much like Makefile. Maybe consider using actual Makefiles? The idea is that each line checks for whether the output exists already. If not, the line would continue executing; else, the line will quitely stop executing.
+(stat ../sha3                                    1>/dev/null 2>&1) || \
+    (ln -s $(readlink -f ../rocc-template) ../sha3)
+(stat ../Makefrag.old                            1>/dev/null 2>&1) || \
+    (mv ../Makefrag ../Makefrag.old && ln -s $(readlink -f ../sha3/config/Makefrag) ../Makefrag)
+(stat ../riscv-tools/riscv-isa-sim/sha3             1>/dev/null 2>&1) || \
+    (ln -s $(readlink -f ../sha3/isa-sim/sha3) ../riscv-tools/riscv-isa-sim/sha3)
+(stat ../riscv-tools/riscv-isa-sim/configure.ac.old 1>/dev/null 2>&1) || \
+    (mv ../riscv-tools/riscv-isa-sim/configure.ac ../riscv-tools/riscv-isa-sim/configure.ac.old && ln -s $(readlink -f ../sha3/isa-sim/configure.ac) ../riscv-tools/riscv-isa-sim/configure.ac && ln -s $(readlink -f ../sha3/isa-sim/riscv-sha3.pc.in) ../riscv-tools/riscv-isa-sim/riscv-sha3.pc.in)
+(stat ../src/main/scala/PrivateConfigs.scala 1>/dev/null 2>&1) || \
+    (ln -s $(readlink -f ../sha3/config/PrivateConfigs.scala) ../src/main/scala/PrivateConfigs.scala)

--- a/isa-sim/configure.ac
+++ b/isa-sim/configure.ac
@@ -81,7 +81,7 @@ AC_SUBST([CXXFLAGS],["-Wall -Wno-unused -O2 -std=c++11"])
 # The '*' suffix indicates an optional subproject. The '**' suffix
 # indicates an optional subproject which is also the name of a group.
 
-MCPPBS_SUBPROJECTS([ riscv, sha3, hwacha, dummy_rocc, softfloat, spike_main ])
+MCPPBS_SUBPROJECTS([ riscv, sha3, dummy_rocc, softfloat, spike_main ])
 
 #-------------------------------------------------------------------------
 # MCPPBS subproject groups
@@ -102,7 +102,6 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([riscv-spike.pc])
 AC_CONFIG_FILES([riscv-riscv.pc])
-AC_CONFIG_FILES([riscv-hwacha.pc])
 AC_CONFIG_FILES([riscv-softfloat.pc])
 AC_CONFIG_FILES([riscv-dummy_rocc.pc])
 AC_CONFIG_FILES([riscv-sha3.pc])


### PR DESCRIPTION
1. The install-symlink script was never written carefully to avoid destructive behaviour is executed multiple times. Therefore, the proposed fix in this commit is to use bash's conditional logical binding to execute the commands based on whether a desired effect is present/exists.
2. In configure.ac, there seem to be a residual configuration bits from previous experiments concerning "hwacha". This was removed and it seems to be working correctly.
